### PR TITLE
Removed GL_ prefixes from enums

### DIFF
--- a/gltfTutorial/gltfTutorial_005_BuffersBufferViewsAccessors.md
+++ b/gltfTutorial/gltfTutorial_005_BuffersBufferViewsAccessors.md
@@ -57,7 +57,7 @@ The first `bufferView` refers to the first 6 bytes of the buffer data. The secon
 
 The bytes that are shown in light gray are padding bytes that are required for properly aligning the accessors, as described below. 
 
-Each `bufferView` additionally contains a `target` property. This property may later be used by the renderer to classify the type or nature of the data that the buffer view refers to. The `target` can be a constant indicating that the data is used for vertex attributes (`34962`, standing for `GL_ARRAY_BUFFER`), or that the data is used for vertex indices (`34963`, standing for `GL_ELEMENT_ARRAY_BUFFER`).
+Each `bufferView` additionally contains a `target` property. This property may later be used by the renderer to classify the type or nature of the data that the buffer view refers to. The `target` can be a constant indicating that the data is used for vertex attributes (`34962`, standing for `ARRAY_BUFFER`), or that the data is used for vertex indices (`34963`, standing for `ELEMENT_ARRAY_BUFFER`).
 
 At this point, the `buffer` data has been divided into multiple parts, and each part is described by one `bufferView`. But in order to really use this data in a renderer, additional information about the type and layout of the data is required.
 
@@ -70,7 +70,7 @@ An [`accessor`](https://github.com/KhronosGroup/glTF/tree/master/specification/2
 
 The type of an accessor's data is encoded in the `type` and the `componentType` properties. The value of the `type` property is a string that specifies whether the data elements are scalars, vectors, or matrices. For example, the value may be `"SCALAR"` for scalar values, `"VEC3"` for 3D vectors, or `"MAT4"` for 4&times;4 matrices.
 
-The `componentType` specifies the type of the components of these data elements. This is a GL constant that may, for example, be `5126` (`GL_FLOAT`) or `5123` (`GL_UNSIGNED_SHORT`), to indicate that the elements have `float` or `unsigned short` components, respectively.
+The `componentType` specifies the type of the components of these data elements. This is a GL constant that may, for example, be `5126` (`FLOAT`) or `5123` (`UNSIGNED_SHORT`), to indicate that the elements have `float` or `unsigned short` components, respectively.
 
 Different combinations of these properties may be used to describe arbitrary data types. For example, the [minimal glTF file](gltfTutorial_003_MinimalGltfFile.md) contained two accessors:
 
@@ -97,9 +97,9 @@ Different combinations of these properties may be used to describe arbitrary dat
   ],
 ```
 
-The first accessor refers to the `bufferView` with index 0, which defines the part of the `buffer` data that contains the indices. Its `type` is `"SCALAR"`, and its `componentType` is `5123` (`GL_UNSIGNED_SHORT`). This means that the indices are stored as scalar `unsigned short` values.
+The first accessor refers to the `bufferView` with index 0, which defines the part of the `buffer` data that contains the indices. Its `type` is `"SCALAR"`, and its `componentType` is `5123` (`UNSIGNED_SHORT`). This means that the indices are stored as scalar `unsigned short` values.
 
-The second accessor refers to the `bufferView` with index 1, which defines the part of the `buffer` data that contains the vertex attributes - particularly, the vertex positions. Its `type` is `"VEC3"`, and its `componentType` is  `5126` (`GL_FLOAT`). So this accessor describes 3D vectors with floating point components.
+The second accessor refers to the `bufferView` with index 1, which defines the part of the `buffer` data that contains the vertex attributes - particularly, the vertex positions. Its `type` is `"VEC3"`, and its `componentType` is  `5126` (`FLOAT`). So this accessor describes 3D vectors with floating point components.
 
 
 ### Data layout
@@ -109,7 +109,7 @@ Additional properties of an `accessor` further specify the layout of the data. T
 
 ### Data alignment
 
-The data that is referred to by an `accessor` may be sent to the graphics card for rendering, or be used at the host side as animation or skinning data. Therefore, the data of an `accessor` has to be aligned based on the *type* of the data. For example, when the `componentType` of an `accessor` is `5126` (`GL_FLOAT`), then the data must be aligned at 4-byte boundaries, because a single `float` value consists of four bytes. This alignment requirement of an `accessor` refers to its `bufferView` and the underlying `buffer`. Particularly, the alignment requirements are as follows:
+The data that is referred to by an `accessor` may be sent to the graphics card for rendering, or be used at the host side as animation or skinning data. Therefore, the data of an `accessor` has to be aligned based on the *type* of the data. For example, when the `componentType` of an `accessor` is `5126` (`FLOAT`), then the data must be aligned at 4-byte boundaries, because a single `float` value consists of four bytes. This alignment requirement of an `accessor` refers to its `bufferView` and the underlying `buffer`. Particularly, the alignment requirements are as follows:
 
 - The `byteOffset` of an `accessor` must be divisible by the size of its `componentType`. 
 - The sum of the `byteOffset` of an accessor and the `byteOffset` of the `bufferView` that it refers to must be divisible by the size of its `componentType`.

--- a/gltfTutorial/gltfTutorial_009_Meshes.md
+++ b/gltfTutorial/gltfTutorial_009_Meshes.md
@@ -47,7 +47,7 @@ The geometry data of a `mesh.primitive` may be either *indexed* geometry or geom
 
 By default, the geometry data is assumed to describe a triangle mesh. For the case of *indexed* geometry, this means that three consecutive elements of the `indices` accessor are assumed to contain the indices of a single triangle. For non-indexed geometry, three elements of the vertex attribute accessors are assumed to contain the attributes of the three vertices of a triangle.
 
-Other rendering modes are possible: the geometry data may also describe individual points, lines, or triangle strips. This is indicated by the `mode` that may be stored in the mesh primitive. Its value is a constant that indicates how the geometry data has to be interpreted. The mode may, for example, be `0` when the geometry consists of points, or `4` when it consists of triangles. These constants correspond to the GL constants `GL_POINTS` or `GL_TRIANGLES`, respectively. See the [`primitive.mode` specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#primitivemode) for a list of available modes.
+Other rendering modes are possible: the geometry data may also describe individual points, lines, or triangle strips. This is indicated by the `mode` that may be stored in the mesh primitive. Its value is a constant that indicates how the geometry data has to be interpreted. The mode may, for example, be `0` when the geometry consists of points, or `4` when it consists of triangles. These constants correspond to the GL constants `POINTS` or `TRIANGLES`, respectively. See the [`primitive.mode` specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#primitivemode) for a list of available modes.
 
 ### Mesh primitive material
 

--- a/gltfTutorial/images/aos.svg
+++ b/gltfTutorial/images/aos.svg
@@ -1456,7 +1456,7 @@
          x="-117.31039"
          y="438.40253"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold';fill:#808080;fill-opacity:1"
-         id="tspan7931">componentType : GL_FLOAT</tspan><tspan
+         id="tspan7931">componentType : FLOAT</tspan><tspan
          sodipodi:role="line"
          x="-117.31039"
          y="457.15253"
@@ -1945,7 +1945,7 @@
          x="-120.29889"
          y="596.28247"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold';fill:#808080;fill-opacity:1"
-         id="tspan7931-6">componentType : GL_FLOAT</tspan><tspan
+         id="tspan7931-6">componentType : FLOAT</tspan><tspan
          sodipodi:role="line"
          x="-120.29889"
          y="615.03247"

--- a/gltfTutorial/images/technique.svg
+++ b/gltfTutorial/images/technique.svg
@@ -977,7 +977,7 @@
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12315">a_position</tspan> in the shader is an attribute.                This parameter has the type <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
-   id="tspan12619">GL_FLOAT_VEC3</tspan> and semantic  <tspan
+   id="tspan12619">FLOAT_VEC3</tspan> and semantic  <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12359">&quot;POSITION&quot;</tspan></tspan></text>
     <rect
@@ -1003,7 +1003,7 @@
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12315-0">u_lightDirection</tspan> is a uniform.                              This parameter has the type <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
-   id="tspan12619-0">GL_FLOAT_VEC3</tspan> and a default <tspan
+   id="tspan12619-0">FLOAT_VEC3</tspan> and a default <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12702">value</tspan></tspan></text>
     <rect
@@ -1029,7 +1029,7 @@
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12315-0-2">u_modelViewMatrix</tspan> is a uniform.                             This parameter has the type <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
-   id="tspan12619-0-5">GL_FLOAT_MAT4</tspan> and semantic <tspan
+   id="tspan12619-0-5">FLOAT_MAT4</tspan> and semantic <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold'"
    id="tspan12702-3">&quot;MODELVIEW&quot;</tspan></tspan></text>
     <path


### PR DESCRIPTION
There are no `GL_` prefixes in the glTF spec