### PR TITLE
Changed 'id' to 'node' for animations/channels/target/__.

### DIFF
--- a/gltfTutorial/gltfTutorial_006_SimpleAnimation.md
+++ b/gltfTutorial/gltfTutorial_006_SimpleAnimation.md
@@ -257,7 +257,7 @@ There is also one `channel` in the example. This channel refers to the only samp
       "channels" : [ {
         "sampler" : 0,
         "target" : {
-          "id" : 0,
+          "node" : 0,
           "path" : "rotation"
         }
       } ]

--- a/gltfTutorial/gltfTutorial_007_Animations.md
+++ b/gltfTutorial/gltfTutorial_007_Animations.md
@@ -25,14 +25,14 @@ The following is another example of an `animation`. This time, the animation con
         {
           "sampler" : 0,
           "target" : {
-            "id" : 0,
+            "node" : 0,
             "path" : "rotation"
           }
         },
         {
           "sampler" : 1,
           "target" : {
-            "id" : 0,
+            "node" : 0,
             "path" : "translation"
           }
         } 


### PR DESCRIPTION
This is a minor change to the animations tutorials. According to the spec here:
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animations,
animations/channels/target should include a 'node' property for specifying 
the target node. Currently, the tutorial has an 'id' property, which I assume
was the original property name.