### PR TITLE
fixed few glTF Spec urls anchors

### DIFF
--- a/gltfTutorial/gltfTutorial_003_MinimalGltfFile.md
+++ b/gltfTutorial/gltfTutorial_003_MinimalGltfFile.md
@@ -109,7 +109,7 @@ More details about scenes and nodes and their properties will be given in the [S
 
 ## The `meshes`
 
-A [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) represents an actual geometric object that appears in the scene. The mesh itself usually does not have any properties, but only contains an array of [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh.primitive) objects, which serve as building blocks for larger models. Each mesh primitive contains a description of the geometry data that the mesh consists of.   
+A [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) represents an actual geometric object that appears in the scene. The mesh itself usually does not have any properties, but only contains an array of [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-primitive) objects, which serve as building blocks for larger models. Each mesh primitive contains a description of the geometry data that the mesh consists of.
 
 The example consists of a single mesh, and has a single `mesh.primitive` object. The mesh primitive has an array of `attributes`. These are the attributes of the vertices of the mesh geometry, and in this case, this is only the `POSITION` attribute, describing the positions of the vertices. The mesh primitive describes an *indexed* geometry, which is indicated by the `indices` property. By default, it is assumed to describe a set of triangles, so that three consecutive indices are the indices of the vertices of one triangle.
 

--- a/gltfTutorial/gltfTutorial_008_SimpleMeshes.md
+++ b/gltfTutorial/gltfTutorial_008_SimpleMeshes.md
@@ -2,7 +2,7 @@ Previous: [Animations](gltfTutorial_007_Animations.md) | [Table of Contents](REA
 
 # Simple Meshes
 
-A [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) represents a geometric object that appears in a scene. An example of a `mesh` has already been shown in the [minimal glTF file](gltfTutorial_003_MinimalGltfFile.md). This example had a single `mesh` attached to a single `node`, and the mesh consisted of a single [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh.primitive) that contained only a single attribute&mdash;namely, the attribute for the vertex positions. But usually, the mesh primitives will contain more attributes. These attributes may, for example, be the vertex normals or texture coordinates.
+A [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) represents a geometric object that appears in a scene. An example of a `mesh` has already been shown in the [minimal glTF file](gltfTutorial_003_MinimalGltfFile.md). This example had a single `mesh` attached to a single `node`, and the mesh consisted of a single [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-primitive) that contained only a single attribute&mdash;namely, the attribute for the vertex positions. But usually, the mesh primitives will contain more attributes. These attributes may, for example, be the vertex normals or texture coordinates.
 
 The following is a glTF asset that contains a simple mesh with multiple attributes, which will serve as the basis for explaining the related concepts:
 

--- a/gltfTutorial/gltfTutorial_009_Meshes.md
+++ b/gltfTutorial/gltfTutorial_009_Meshes.md
@@ -2,7 +2,7 @@ Previous: [Simple Meshes](gltfTutorial_008_SimpleMeshes.md) | [Table of Contents
 
 # Meshes
 
-The [Simple Meshes](gltfTutorial_008_SimpleMeshes.md) example from the previous section showed a basic example of a [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) with a [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh.primitive) object that contained several attributes. This section will explain the meaning and usage of mesh primitives, how meshes may be attached to nodes of the scene graph, and how they can be rendered with different materials.
+The [Simple Meshes](gltfTutorial_008_SimpleMeshes.md) example from the previous section showed a basic example of a [`mesh`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-mesh) with a [`mesh.primitive`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-primitive) object that contained several attributes. This section will explain the meaning and usage of mesh primitives, how meshes may be attached to nodes of the scene graph, and how they can be rendered with different materials.
 
 
 ## Mesh primitives

--- a/gltfTutorial/gltfTutorial_016_Cameras.md
+++ b/gltfTutorial/gltfTutorial_016_Cameras.md
@@ -35,7 +35,7 @@ The example in the [Simple Cameras](gltfTutorial_017_SimpleCameras.md) section c
 ```
 
 
-The `type` of the camera is given as a string, which can be `"perspective"` or  `"orthographic"`. Depending on this type, the `camera` object contains a [`camera.perspective`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-camera.perspective) object or a [`camera.orthographic`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-camera.orthographic) object. These objects contain additional parameters that define the actual viewing volume.
+The `type` of the camera is given as a string, which can be `"perspective"` or  `"orthographic"`. Depending on this type, the `camera` object contains a [`camera.perspective`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-perspective) object or a [`camera.orthographic`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/#reference-orthographic) object. These objects contain additional parameters that define the actual viewing volume.
 
 The `camera.perspective` object contains an `aspectRatio` property that defines the aspect ratio of the viewport. Additionally, it contains a property called `yfov`, which stands for *Field Of View in Y-direction*. It defines the "opening angle" of the camera and is given in radians.
 


### PR DESCRIPTION
The in page links anchors to a mesh.primitive, camera.orthographic, and camera.perspective were wrong and didn't scroll down to the section

`#reference-mesh.primitive` -> `#reference-primitive`
`#reference-camera.perspective` -> `#reference-perspective`
`#reference-camera.orthographic` -> `#reference-orthographic`