### PR TITLE
Clarify quaternion component order

### DIFF
--- a/gltfTutorial/gltfTutorial_004_ScenesNodes.md
+++ b/gltfTutorial/gltfTutorial_004_ScenesNodes.md
@@ -97,7 +97,7 @@ Each of these properties can be used to create a matrix, and the product of thes
 </p>
 
 
-- The `rotation` is given as a [quaternion](https://en.wikipedia.org/wiki/Quaternion). The mathematical background of quaternions is beyond the scope of this tutorial. For now, the most important information is that a quaternion is a compact representation of a rotation about an arbitrary angle and around an arbitrary axis. For example, the quaternion `[ 0.259, 0.0, 0.0, 0.966 ]` describes a rotation about 30 degrees, around the x-axis. So this quaternion can be converted into a rotation matrix, as shown in Image 4d.
+- The `rotation` is given as a [quaternion](https://en.wikipedia.org/wiki/Quaternion). The mathematical background of quaternions is beyond the scope of this tutorial. For now, the most important information is that a quaternion is a compact representation of a rotation about an arbitrary angle and around an arbitrary axis. It is stored as a tuple `(x,y,z,w)`, where the `w`-component is the cosine of half of the rotation angle. For example, the quaternion `[ 0.259, 0.0, 0.0, 0.966 ]` describes a rotation about 30 degrees, around the x-axis. So this quaternion can be converted into a rotation matrix, as shown in Image 4d.
 
 <p align="center">
 <img src="images/rotationMatrix.png" /><br>


### PR DESCRIPTION
(This is supposed to be merged after https://github.com/KhronosGroup/glTF-Tutorials/pull/65)

Fixes https://github.com/KhronosGroup/glTF-Tutorials/issues/61


