### PR TITLE
Various link & spelling fixes, updated converter section.

### DIFF
--- a/AddingMaterialExtensions/README.md
+++ b/AddingMaterialExtensions/README.md
@@ -2,14 +2,14 @@
 
 By Eric Chadwick, Staff Technical Artist, Wayfair, [@echadwick-wayfair](https://github.com/echadwick-wayfair)
 
-This tutorial explains how to edit glTF files using open source software to add material extensions [KHR_materials_transmission](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_materials_transmission/README.md) and [KHR_materials_volume](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_materials_volume/README.md) to create glass with reflection, refraction, and absorption. 
+This tutorial explains how to edit glTF files using open source software to add material extensions [KHR_materials_transmission](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_transmission/README.md) and [KHR_materials_volume](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md) to create glass with reflection, refraction, and absorption. 
 
 These methods can be repurposed for [other material extensions](https://github.com/KhronosGroup/glTF/tree/main/extensions#gltf-extension-registry) too.
 
 
 ## Sample Model ##
 
-The glTF model used in this tutorial is available in the [/samples](https://github.com/KhronosGroup/glTF-Tutorials/blob/master/AddingMaterialExtensions/samples/) folder. 
+The glTF model used in this tutorial is available in the [/samples](https://github.com/KhronosGroup/glTF-Tutorials/blob/main/AddingMaterialExtensions/samples/) folder. 
 
 ![screenshot of GlassHurricaneCandleHolder.gltf with transmission and volume](images/image20.jpg "screenshot of GlassHurricaneCandleHolder.gltf with transmission and volume")
 

--- a/gltfTutorial/README.md
+++ b/gltfTutorial/README.md
@@ -4,7 +4,7 @@ By Marco Hutter, [@javagl](https://github.com/javagl)
 
 This tutorial gives an introduction to [glTF](https://www.khronos.org/gltf), the GL transmission format. It summarizes the most important features and application cases of glTF, and describes the structure of the files that are related to glTF. It explains how glTF assets may be read, processed, and used to display 3D graphics efficiently.
 
-Some basic knowledge about [JSON](https://json.org/), the JavaScript Object Notation, is assumed. Additionally, a basic understanding of common graphics APIs, like OpenGL or WebGL, is required. This tutorial focuses on [glTF version 2.0](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html), where support for *Physically Based Rendering* was introduced, but the other concepts that are explained here are similar to how they had been implemented in [glTF version 1.0](https://github.com/KhronosGroup/glTF/tree/master/specification/1.0). 
+Some basic knowledge about [JSON](https://json.org/), the JavaScript Object Notation, is assumed. Additionally, a basic understanding of common graphics APIs, like OpenGL or WebGL, is required. This tutorial focuses on [glTF version 2.0](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html), where support for *Physically Based Rendering* was introduced, but the other concepts that are explained here are similar to how they had been implemented in [glTF version 1.0](https://github.com/KhronosGroup/glTF/tree/main/specification/1.0). 
 
 
 - [Introduction](gltfTutorial_001_Introduction.md)

--- a/gltfTutorial/gltfTutorial_001_Introduction.md
+++ b/gltfTutorial/gltfTutorial_001_Introduction.md
@@ -48,7 +48,7 @@ Different content creation tools may now provide 3D content in the glTF format. 
 <a name="contentPipelineWithGltf-png"></a>Image 1c: The 3D content pipeline with glTF.
 </p>
 
-An increasing number of content creation tools will be able to provide glTF directly. Alternatively, other file formats can be used to create glTF assets, using one of the open-source conversion utilities listed in the [Khronos glTF repository](https://github.com/KhronosGroup/glTF#converters). For example, nearly all authoring applications can export their scenes in the [COLLADA](https://www.khronos.org/collada/) format. So the [COLLADA2GLTF](https://github.com/KhronosGroup/COLLADA2GLTF) tool can be used to convert scenes and models from these authoring applications to glTF. `OBJ` files may be converted to glTF using [obj2gltf](https://github.com/AnalyticalGraphicsInc/obj2gltf). For other file formats, custom converters can be used to create glTF assets, thus making the 3D content available for a broad range of runtime applications.
+An increasing number of content creation tools provide glTF import and export directly. For example, the Blender Manual documents [how to import and export PBR materials](https://docs.blender.org/manual/en/latest/addons/import_export/scene_gltf2.html) using glTF.  Alternatively, other file formats can be used to create glTF assets, using one of the open-source conversion utilities listed in the [glTF Project Explorer](https://github.khronos.org/glTF-Project-Explorer/). The output of converters and exporters can be validated using the [Khronos glTF Validator](https://github.khronos.org/glTF-Validator/).
 
 
 [Table of Contents](README.md) | Next: [Basic glTF Structure](gltfTutorial_002_BasicGltfStructure.md)

--- a/gltfTutorial/gltfTutorial_003_MinimalGltfFile.md
+++ b/gltfTutorial/gltfTutorial_003_MinimalGltfFile.md
@@ -240,7 +240,7 @@ In glTF 1.0, this property is still optional, but in subsequent glTF versions, t
   }
 ```
 
-The `asset` property may contain additional metadata that is described in the [`asset` specification](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md#reference-asset).
+The `asset` property may contain additional metadata that is described in the [`asset` specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-asset).
 
 
 

--- a/gltfTutorial/gltfTutorial_005_BuffersBufferViewsAccessors.md
+++ b/gltfTutorial/gltfTutorial_005_BuffersBufferViewsAccessors.md
@@ -130,7 +130,7 @@ The data of the attributes that are stored in a single `bufferView` may be store
 
 <p align="center">
 <img src="images/aos.png" /><br>
-<a name="aos-png"></a>Image 5d: Interleaved acessors in one buffer view.
+<a name="aos-png"></a>Image 5d: Interleaved accessors in one buffer view.
 </p>
 
 

--- a/gltfTutorial/gltfTutorial_007_Animations.md
+++ b/gltfTutorial/gltfTutorial_007_Animations.md
@@ -145,7 +145,7 @@ For scalar and vector types, use a linear interpolation (generally called `lerp`
         return previousPoint + interpolationValue * (nextPoint - previousPoint)
 ```
 
-In the case of rotations expressed as quaternions, you need to perform a spherical linear intepolation (`slerp`) between the previous and next values:
+In the case of rotations expressed as quaternions, you need to perform a spherical linear interpolation (`slerp`) between the previous and next values:
 
 ```
     Quat slerp(previousQuat, nextQuat, interpolationValue)
@@ -171,7 +171,7 @@ In the case of rotations expressed as quaternions, you need to perform a spheric
         return scalePreviousQuat * previousQuat + scaleNextQuat * nextQuat
 ```
 
-This example implementation is inspired from this [wikipedia article](https://en.wikipedia.org/wiki/Slerp)
+This example implementation is inspired from this [Wikipedia article](https://en.wikipedia.org/wiki/Slerp)
 
 ### Cubic Spline interpolation
 

--- a/gltfTutorial/gltfTutorial_014_AdvancedMaterial.md
+++ b/gltfTutorial/gltfTutorial_014_AdvancedMaterial.md
@@ -42,7 +42,7 @@ Image 14d shows the emissive part of the texture: regardless of the dark environ
 <a name="advancedMaterial_emissive-png"></a>Image 14d: The emissive part of the texture.
 </p>
 
-Image 14e shows the part of the bottl cap for which a normal map is defined: the text appears to be embossed into the cap. This makes it possible to model finer geometric details on the surface, even though the model itself only has a very coarse geometric resolution.
+Image 14e shows the part of the bottle cap for which a normal map is defined: the text appears to be embossed into the cap. This makes it possible to model finer geometric details on the surface, even though the model itself only has a very coarse geometric resolution.
 
 <p align="center">
 <img src="images/advancedMaterial_normal.png" /><br>


### PR DESCRIPTION
A few more link updates, and some spelling corrections (one found by me, the rest from spell-check).

Also, I rewrote a small section on converting glTF files at the bottom of section 1, Introduction.  It had links out to tools that don't see much maintenance anymore, such as COLLADA2GLTF.  I replaced these with links to the glTF Project Explorer, the Blender Manual's section on glTF, and the Khronos glTF Validator.