### PR TITLE
Added short contributing guide to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,20 @@
 - The main [glTF Tutorial](gltfTutorial/README.md).
 - A tutorial about [Physically Based Rendering (PBR) in glTF](PBR/README.md).
 - A tutorial for [Adding Material Extensions to glTF Models](AddingMaterialExtensions/README.md).
-- A template for [Building glTF conversion tool based on Blender](BlenderGltfConverter/README.md).
+- A template for [Building a glTF conversion tool based on Blender](BlenderGltfConverter/README.md).
+
+An online HTML version of these tutorials can be found at https://github.khronos.org/glTF-Tutorials/ .
+
+## Feedback
+
+If there are any tutorials that you would like to see here, you can open a new issue to share your ideas, or add your suggestions to the [Contributions to the glTF-Tutorials issue](https://github.com/KhronosGroup/glTF-Tutorials/issues/8).
+
+## Contributing
+
+If you want to contribute your own tutorial, you can do this in diffrent ways:
+
+You can open an issue to propose the new tutorial that you want to create. In this issue, you can discuss the intended topic, scope, and structure of the tutorial. This will allow you to gather early feedback, and maybe even find collaborators who would like to support you.
+
+If you have already created a tutorial and want to make it available here, you can just open a pull request. The new tutorial should be in a subdirectory with a short, distinctive name that indicates the overall topic of the tutorial, in `CamelCase` or `lowerCamelCase`. Inside this directory, there should be a `README.md` file that serves as the entry point. Beyond that, you can structure your tutorial as you see fit: If it is a short tutorial, it could be fully contained in the `README.md` file. If you want to split it up into multiple sections, then you can create one markdown file for each section, and only put a Table Of Contents into the `README.md` file. You can also create further subdirectories, for example, a dedicated `images` directory for all the images that you want to inline.
+
+The tutorials will be published here under the [CC-BY 4.0 license](https://github.com/KhronosGroup/glTF-Tutorials/blob/master/LICENSE). 


### PR DESCRIPTION
Added a short "Feedback" and "Contributing" guide to the main README. 

Direct preview link: https://github.com/javagl/glTF-Tutorials/blob/add-contributing-guide/README.md 

