### PR TITLE
Fix link to samples folder

### DIFF
--- a/AddingMaterialExtensions/README.md
+++ b/AddingMaterialExtensions/README.md
@@ -9,7 +9,7 @@ These methods can be repurposed for [other material extensions](https://github.c
 
 ## Sample Model ##
 
-The glTF model used in this tutorial is available in the [/samples](https://github.com/KhronosGroup/glTF-Tutorials/blob/main/AddingMaterialExtensions/samples/) folder. 
+The glTF model used in this tutorial is available in the [samples](samples/) folder.
 
 ![screenshot of GlassHurricaneCandleHolder.gltf with transmission and volume](images/image20.jpg "screenshot of GlassHurricaneCandleHolder.gltf with transmission and volume")
 


### PR DESCRIPTION
The [link to the samples directory here](https://github.com/KhronosGroup/glTF-Tutorials/blob/a4ff69c27908304d9a6bf771fcff9b2c3ceb6abb/AddingMaterialExtensions/README.md#sample-model) led nowhere.
