### PR TITLE
Fix small typo in "Simple Morph Target"

### DIFF
--- a/gltfTutorial/gltfTutorial_017_SimpleMorphTarget.md
+++ b/gltfTutorial/gltfTutorial_017_SimpleMorphTarget.md
@@ -236,7 +236,7 @@ The new elements that have been added in order to define the morph targets are c
         }
       ],
       "weights":[
-        0.5,
+        1.0,
         0.5
       ]
     }

--- a/gltfTutorial/gltfTutorial_017_SimpleMorphTarget.md
+++ b/gltfTutorial/gltfTutorial_017_SimpleMorphTarget.md
@@ -41,7 +41,7 @@ The following is a minimal example that shows a mesh with two morph targets. The
         }
       ],
       "weights":[
-        1.0,
+        0.5,
         0.5
       ]
     }
@@ -236,7 +236,7 @@ The new elements that have been added in order to define the morph targets are c
         }
       ],
       "weights":[
-        1.0,
+        0.5,
         0.5
       ]
     }

--- a/gltfTutorial/gltfTutorial_018_MorphTargets.md
+++ b/gltfTutorial/gltfTutorial_018_MorphTargets.md
@@ -25,7 +25,7 @@ The example in the previous section contains a mesh that consists of a single tr
         }
       ],
       "weights":[
-        1.0,
+        0.5,
         0.5
       ]
     }


### PR DESCRIPTION
This is a very small correction to the documentation.

But it is important because this section explains morphing and linear interpolation. 